### PR TITLE
chore(infra): bump rails security fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (8.0.2)
-      activesupport (= 8.0.2)
-    activesupport (8.0.2)
+    activemodel (8.0.2.1)
+      activesupport (= 8.0.2.1)
+    activesupport (8.0.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal


### PR DESCRIPTION
https://rubyonrails.org/2025/8/13/Rails-Versions-8-0-2-1-7-2-2-2-and-7-1-5-2-have-been-released