### PR TITLE
chore: tighten activesupport constraint from >= 3.0 to >= 6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     subroutine-factory (0.3.0)
-      activesupport (>= 3.0)
+      activesupport (>= 6.1)
       subroutine
 
 GEM

--- a/subroutine-factory.gemspec
+++ b/subroutine-factory.gemspec
@@ -27,10 +27,11 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"] + Dir["*.gemspec"] + Dir["bin/**/*"]
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.required_ruby_version = ">= 3.2.0"
   spec.require_paths = ["lib"]
 
   spec.add_dependency "subroutine"
-  spec.add_dependency "activesupport", ">= 3.0"
+  spec.add_dependency "activesupport", ">= 6.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
## Summary
- Tightens activesupport dependency from `>= 3.0` to `>= 6.1` to match the transitive requirement from subroutine
- Adds `required_ruby_version >= 3.2.0` to reflect actual Ruby version requirement

## Test plan
- [ ] CI passes (existing tests should be unaffected since no runtime behavior changes)
- [ ] Verify `bundle install` resolves correctly

RETIRE-6311

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightening runtime requirements may break consumers on older Ruby/ActiveSupport versions even though no runtime logic changes were made.
> 
> **Overview**
> Updates `subroutine-factory`'s published requirements by tightening the `activesupport` dependency from `>= 3.0` to `>= 6.1` and declaring `required_ruby_version >= 3.2.0` in the gemspec.
> 
> Regenerates `Gemfile.lock` to reflect the new `activesupport` constraint for the path gem.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0b3834fe61abe6904467125c73668f125826001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->