### PR TITLE
Drop Ruby 3.2 from CI test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.2, 3.3, 3.4]
+        ruby-version: [3.3, 3.4]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    subroutine-factory (0.3.0)
+    subroutine-factory (0.4.0)
       activesupport (>= 6.1)
       subroutine
 
@@ -90,7 +90,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   subroutine (4.5.0) sha256=6868cde4c51a100b256aba558f52e4a44aa4e8451b5f755b12fa5495ee4f1df5
-  subroutine-factory (0.3.0)
+  subroutine-factory (0.4.0)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 

--- a/lib/subroutine/factory/version.rb
+++ b/lib/subroutine/factory/version.rb
@@ -3,7 +3,7 @@
 module Subroutine
   module Factory
 
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
 
   end
 end

--- a/subroutine-factory.gemspec
+++ b/subroutine-factory.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"] + Dir["*.gemspec"] + Dir["bin/**/*"]
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
   spec.require_paths = ["lib"]
 
   spec.add_dependency "subroutine"


### PR DESCRIPTION
Remove Ruby 3.2 from CI test matrix, bump minor version.

Ruby 3.2 EOL prep — aligning CI matrix with supported versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change focused on CI/support policy; the main impact is that Ruby 3.2 users will no longer be supported/tested and may hit compatibility issues.
> 
> **Overview**
> Drops Ruby `3.2` from the GitHub Actions test matrix and raises the gem’s required Ruby version to `>= 3.3.0`.
> 
> Bumps `subroutine-factory` to `0.4.0` (updating `VERSION` and `Gemfile.lock`) to reflect the support-policy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c3c5cd5a6c2d26e919681f7cccdcc9b3f2b517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->