### PR TITLE
chore: gemspec cleanup — metadata, activesupport >= 8.0, v0.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    subroutine-factory (0.4.0)
-      activesupport (>= 6.1)
+    subroutine-factory (0.5.0)
+      activesupport (>= 8.0)
       subroutine
 
 GEM
@@ -91,7 +91,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   subroutine (4.6.0) sha256=de7b857ab9b585830b8ce71bc8670ae80d1fd9387412fb69bc52a9af015a3d77
-  subroutine-factory (0.4.0)
+  subroutine-factory (0.5.0)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 

--- a/lib/subroutine/factory/version.rb
+++ b/lib/subroutine/factory/version.rb
@@ -3,7 +3,7 @@
 module Subroutine
   module Factory
 
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
 
   end
 end

--- a/subroutine-factory.gemspec
+++ b/subroutine-factory.gemspec
@@ -1,7 +1,8 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'subroutine/factory/version'
+require "subroutine/factory/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "subroutine-factory"
@@ -9,33 +10,32 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Mike Nelson"]
   spec.email         = ["mike@mnelson.io"]
 
-  spec.summary       = %q{Test factories for ops using Subroutine Ops}
-  spec.description   = %q{Test factories for ops using Subroutine Ops}
-  spec.homepage      = "https://github.com/guideline-tech/subroutine-factory"
+  spec.summary       = "Test factories for ops using Subroutine Ops"
+  spec.description   = "Test factories for ops using Subroutine Ops"
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
-    spec.metadata["rubygems_mfa_required"] = "true"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  # Specify which files should be added to the gem when it is released.
+  github_uri = "https://github.com/guideline-tech/subroutine-factory"
+
+  spec.homepage = github_uri
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = github_uri
+  spec.metadata["changelog_uri"] = "#{github_uri}/releases"
+  spec.metadata["github_repo"] = github_uri
+  spec.metadata["rubygems_mfa_required"] = "true"
+
   spec.files = Dir["lib/**/*"] + Dir["*.gemspec"] + Dir["bin/**/*"]
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.required_ruby_version = ">= 3.3.0"
   spec.require_paths = ["lib"]
 
   spec.add_dependency "subroutine"
-  spec.add_dependency "activesupport", ">= 6.1"
+  spec.add_dependency "activesupport", ">= 8.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"
-
 end


### PR DESCRIPTION
## Summary

- **Gemspec rewrite**: modernize style (`frozen_string_literal`, `__dir__`, double-quoted strings), remove old `respond_to?(:metadata)` guard (RubyGems 2.0+ is assumed)
- **`github_uri` constant**: replaces repeated URL literals; adds `homepage_uri`, `source_code_uri`, `changelog_uri` (releases page), `github_repo`
- **`activesupport`**: bump `>= 6.1` → `>= 8.0`
- **Version**: 0.4.0 → 0.5.0 (minor bump for dep change)
- **`bundle update`**: Gemfile.lock refreshed

A new release will be kicked once merged.