### PR TITLE
Declare irb as a development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,15 @@ GEM
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     drb (2.2.3)
+    erb (6.0.6)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.21.1)
     logger (1.7.0)
     minitest (6.0.6)
@@ -43,8 +50,22 @@ GEM
       minitest (>= 5.0, < 7)
       ruby-progressbar
     mutex_m (0.3.0)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.9.0)
     rake (13.4.2)
+    rbs (4.1.0)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    reline (0.6.3)
+      io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     subroutine (4.7.0)
@@ -54,6 +75,7 @@ GEM
       bigdecimal
       logger
       mutex_m
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.1.1)
@@ -64,6 +86,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  irb
   minitest
   minitest-reporters
   rake
@@ -80,18 +103,27 @@ CHECKSUMS
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   minitest-reporters (1.8.0) sha256=8ce5280fb73ad3178ae525454df169b6f28c1b38b1d088ea91815d3a370ba384
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.1.0) sha256=8baba59008b0643b4ba2090e9b1d0149655b0bbd42eb2ffe42b1d0eb6923fd72
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   subroutine (4.7.0) sha256=da73a22a3df0aa17cd51d8af7fdc52a5400b3fc4ba4a9bdfc8d250327bf1ea82
   subroutine-factory (0.5.0)
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 

--- a/subroutine-factory.gemspec
+++ b/subroutine-factory.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 8.0"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "irb"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"


### PR DESCRIPTION
## Findings

Audited every `require` in `lib/`, `test/`, `bin/`, and the Rakefile against the gemspec, Gemfile, and Gemfile.lock, with a focus on Ruby default gems that have been (or are being) demoted to bundled gems.

| Require | Where | Status |
| --- | --- | --- |
| `irb` | `bin/console:13` | **Missing.** Bundled gem as of Ruby 4.0 (`Gem::BUNDLED_GEMS::SINCE["irb"] == "4.0.0"`, and present in ruby/ruby master `gems/bundled_gems`). Not declared anywhere, not in the lockfile. |
| `securerandom` | `lib/subroutine/factory.rb:3` | OK. Still a true default gem — absent from `gems/bundled_gems` on ruby/ruby master and present in `Gem::Specification.default_stubs`. Also already resolved transitively in the lockfile. |
| `subroutine`, `active_support/*` | `lib/` | OK — declared runtime deps. |
| `minitest`, `minitest-reporters` | `test/` | OK — declared dev deps. |
| `bundler/setup`, `bundler/gem_tasks`, `rake/testtask` | `bin/`, Rakefile | OK — declared dev deps. |

No bare stdlib constant usage without a matching require (only `IRB.start`, covered above).

## Changes

- `subroutine-factory.gemspec`: added `spec.add_development_dependency "irb"`. Development rather than runtime because `bin/console` starts with `require "bundler/setup"`, so it is only usable from inside this repo's own bundle.
- `Gemfile.lock`: regenerated via `bundle install`. The only additions are irb and its dependency closure (pp, prettyprint, prism-adjacent rdoc/rbs, reline, io-console, erb, tsort). No unrelated version bumps.

No Appraisals file or `gemfiles/` directory, so no appraisal update needed.

`.github/dependabot.yml` needs no change: the bundler `monthly` group already matches `*` with excludes only for rails/active*, so irb is covered.

## Test plan

- `bundle install` — clean.
- `bundle exec rake` — 7 tests, 15 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec bin/console` — starts IRB successfully.
- No rubocop config in this repo.
