### PR TITLE
Bump patch version to 0.5.1 and update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    subroutine-factory (0.5.0)
+    subroutine-factory (0.5.1)
       activesupport (>= 8.0)
       subroutine
 
@@ -99,7 +99,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
@@ -122,10 +122,10 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   subroutine (4.7.0) sha256=da73a22a3df0aa17cd51d8af7fdc52a5400b3fc4ba4a9bdfc8d250327bf1ea82
-  subroutine-factory (0.5.0)
+  subroutine-factory (0.5.1)
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
-  4.0.16
+  4.0.17

--- a/lib/subroutine/factory/version.rb
+++ b/lib/subroutine/factory/version.rb
@@ -3,7 +3,7 @@
 module Subroutine
   module Factory
 
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
 
   end
 end


### PR DESCRIPTION
Routine patch version bump (0.5.0 -> 0.5.1) and bundler pin sync (4.0.16 -> 4.0.17) via `bundle update --bundler`.

Test suite passes: 7 tests, 15 assertions, 0 failures.

No Appraisals setup in this repo, so no appraisal lockfiles to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)