### PR TITLE
Require Rails 8.1 and drop activesupport 8.0 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     subroutine-factory (0.5.1)
-      activesupport (>= 8.0)
+      activesupport (>= 8.1)
       subroutine
 
 GEM

--- a/subroutine-factory.gemspec
+++ b/subroutine-factory.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "subroutine"
-  spec.add_dependency "activesupport", ">= 8.0"
+  spec.add_dependency "activesupport", ">= 8.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "irb"


### PR DESCRIPTION
## What

Drops `activesupport` 8.0 support from `subroutine-factory`, leaving 8.1 as the minimum.

- `subroutine-factory.gemspec`: `activesupport` constraint bumped from `>= 8.0` to `>= 8.1`.
- Regenerated `Gemfile.lock`.

No Appraisals setup or Rails-version conditional code exists in this repo, so there was nothing else to clean up. The lockfile diff is limited to the dependency constraint line — no gem versions moved.

## Why now

Rails 8.0 has already reached end of bug-fix support (2026-05-07) and reaches full end of security support on 2026-11-07, per the [Rails end-of-support announcement](https://rubyonrails.org/2025/10/29/new-rails-releases-and-end-of-support-announcement). Bumping the floor now gets this gem onto supported Rails 8.1 ahead of that deadline.

## Testing

- `bundle exec rake test`: 7 tests, 15 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)