### PR TITLE
test vs latest subroutine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,9 +68,9 @@ GEM
       io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    subroutine (4.7.1)
-      activemodel (>= 8.0)
-      activesupport (>= 8.0)
+    subroutine (4.8.0)
+      activemodel (>= 8.1)
+      activesupport (>= 8.1)
       base64
       bigdecimal
       logger
@@ -99,7 +99,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
+  bundler (4.0.19) sha256=b48056e4c77fb3853cc47775b5447ede44aaa4f53c32f168014ab4fe86587d47
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
@@ -121,11 +121,11 @@ CHECKSUMS
   reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  subroutine (4.7.1) sha256=748f05ad547935f3be98502c149d97631067653ad13bd97e3009917a4b355ef3
+  subroutine (4.8.0) sha256=6c0ac25fd4e9e589a9c8e96e2d5343c2085176da855356115b0506616c44a832
   subroutine-factory (0.6.0)
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
-  4.0.18
+  4.0.19


### PR DESCRIPTION
Subroutine was bumped to remove Rails 8.0 support, so make sure we test vs latest subroutine explicitly to be sure